### PR TITLE
Regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Valid paths are strings conforming to the following BNF syntax.
 
 <recursive descent> ::= ".." <dotted child name> |                 ; all the descendants named <dotted child name>
                         ".." <array access>  |                     ; array access of all descendents
-<array access> ::= "[" union "]" | "[" <filter> "]"                ; zero or more elements of a sequence
+<array access> ::= "[" "*" "]" | [" union "]" | "[" <filter> "]"   ; all, zero or more elements of a sequence
 
 <union> ::= <index> | <index> "," <union>
-<index> ::= <integer> | <range> | "*"                              ; specific index, range of indices, or all indices
+<index> ::= <integer> | <range>                                    ; specific index, range of indices
 <range> ::= <integer> ":" <integer> |                              ; start (inclusive) to end (exclusive)
             <integer> ":" <integer> ":" <integer>                  ; start (inclusive) to end (exclusive) by step
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JSONPath implementation for the [YAML node](https://godoc.org/gopkg.in/yaml.v3#N
 
 Valid paths are strings conforming to the following BNF syntax.
 
-```
+```bnf
 <path> ::= <identity> | <root> <subpath> | <subpath> |
            <undotted child> <subpath> | <subpath> <filter>         ; an undotted child is allowed at the start of a path
 <identity> ::= ""                                                  ; the current node
@@ -40,11 +40,12 @@ Valid paths are strings conforming to the following BNF syntax.
                            ""                                      ; empty string
 
 <recursive descent> ::= ".." <dotted child name> |                 ; all the descendants named <dotted child name>
+                        ".." <bracket child> |                     ; object access of all descendents
                         ".." <array access>  |                     ; array access of all descendents
-<array access> ::= "[" "*" "]" | [" union "]" | "[" <filter> "]"   ; all, zero or more elements of a sequence
+<array access> ::= "[" "*" "]" | "[" union "]" | "[" <filter> "]"  ; all, zero or more elements of a sequence
 
 <union> ::= <index> | <index> "," <union>
-<index> ::= <integer> | <range>                                    ; specific index, range of indices
+<index> ::= <integer> | <range>                                    ; specific index, range of indices, or all indices
 <range> ::= <integer> ":" <integer> |                              ; start (inclusive) to end (exclusive)
             <integer> ":" <integer> ":" <integer>                  ; start (inclusive) to end (exclusive) by step
 
@@ -107,12 +108,13 @@ This matches the root node of the input YAML node. This matcher may be specified
 
 This matches the children with the given names of all the mapping nodes in the input slice. The output slice consists of all those children. The given name may be a single child name (no periods) or a series of single child names separated by periods. Non-mapping nodes in the input slice are not matched.
 
-Although either form `.childname` or `['childname']` accepts a child name with embedded spaces, the 
+Although either form `.childname` or `['childname']` accepts a child name with embedded spaces, the
 `['childname']` form may be more convenient in some situations.
 
 As a special case, `.*` also matches all the nodes in each sequence node in the input slice.
 
-## Property Name:
+## Property Name
+
 The Property Name Operator `~` can be included after a child name in the form of `.childname~`, `['childname']~` or `['childname1', "childname2"]~` to return the property name of the node instead of the value. this can only be used on the last part of the path
 
 ### Recursive Descent: `..childname` or `..*`
@@ -138,11 +140,13 @@ A matcher of the form `[*]` selects all the nodes in each sequence node.
 This matcher selects a subset of each node in the input satisfying the filter expression.
 
 Filter expressions are composed of three kinds of term:
+
 * `@` terms which produce a slice of descendants of the current node being matched (which is a node in one of the input sequences). Any path expression may be appended after the `@` to determine which descendants to include.
 * `$` terms which produce a slice of descendants of the root node. Any path expression may be appended after the `$` to determine which descendants to include.
 * Integer, floating point, and string literals (enclosed in single quotes, e.g. 'x').
 
 Filter expressions combine terms into basic filters of various sorts:
+
 * existence filters, which consist of just a `@` or `$` term, are true if and only if the given term produces a non-empty slice of descendants.
 * comparison filters (`==`, `!=`, `>`, `>=`, `<`, `<=`, `=~`) are true if and only if the same comparison is true of the values of each pair of items produced by the terms on each side of the comparison except that an empty slice always compares as false.
 
@@ -151,7 +155,7 @@ Comparison filters are normally used to compare a term which produces a slice co
 The more general case is a logical extension of this. Each value on the left hand side must pass the comparison with each value on the right hand side, except that if either side is empty, then the comparison filter
 is false (because there were no matches on that side).
 
-Comparison expressions are built from existence and/or comparison filters using familiar logical operators -- disjunction ("or", `||`), conjunction ("and", `&&`), and negation ("not", `!`) -- together with parenthesised expressions. 
+Comparison expressions are built from existence and/or comparison filters using familiar logical operators -- disjunction ("or", `||`), conjunction ("and", `&&`), and negation ("not", `!`) -- together with parenthesised expressions.
 
 ## Trying it out
 
@@ -171,12 +175,14 @@ The following sources inspired the syntax and semantics of YAML JSONPath:
 ## Developing
 
 Run the tests as usual:
-```
+
+```sh
 go test ./...
 ```
 
 Check linting (so you don't get caught out by CI), after installing [golangci-lint](https://golangci-lint.run/):
-```
+
+```sh
 ./scripts/check-lint.sh
 ```
 

--- a/pkg/yamlpath/comparison.go
+++ b/pkg/yamlpath/comparison.go
@@ -79,7 +79,8 @@ func compareNodeValues(lhs, rhs typedValue) comparison {
 		return compareFloat64(mustParseFloat64(lhs.val), mustParseFloat64(rhs.val))
 	}
 	if (lhs.typ != stringValueType && !lhs.typ.isNumeric()) || (rhs.typ != stringValueType && !rhs.typ.isNumeric()) {
-		panic("invalid type of value passed to compareNodeValues") // should never happen
+		// we cannot compare values
+		return compareIncomparable
 	}
 	return compareStrings(lhs.val, rhs.val)
 }

--- a/pkg/yamlpath/filter.go
+++ b/pkg/yamlpath/filter.go
@@ -102,13 +102,6 @@ func comparisonFilter(n *filterNode) filter {
 	})
 }
 
-var x, y typedValue
-
-func init() {
-	x = typedValue{stringValueType, "x"}
-	y = typedValue{stringValueType, "y"}
-}
-
 func nodeToFilter(n *filterNode, accept func(typedValue, typedValue) bool) filter {
 	lhsPath := newFilterScanner(n.children[0])
 	rhsPath := newFilterScanner(n.children[1])

--- a/pkg/yamlpath/lexer.go
+++ b/pkg/yamlpath/lexer.go
@@ -530,7 +530,7 @@ func lexSubPath(l *lexer) stateFn {
 			}
 			childName = true
 		}
-		if !childName && !l.peeked(leftBracket, bracketQuote, bracketDoubleQuote) {
+		if !childName && !l.peeked(leftBracket) {
 			return l.errorf("child name or array access or filter missing after recursive descent")
 		}
 		l.emit(lexemeRecursiveDescent)

--- a/pkg/yamlpath/lexer_test.go
+++ b/pkg/yamlpath/lexer_test.go
@@ -834,7 +834,9 @@ func TestLexer(t *testing.T) {
 			path: "$..['child']",
 			expected: []lexeme{
 				{typ: lexemeRoot, val: "$"},
-				{typ: lexemeError, val: `child name or array access or filter missing after recursive descent at position 3, following "$.."`},
+				{typ: lexemeRecursiveDescent, val: ".."},
+				{typ: lexemeBracketChild, val: "['child']"},
+				{typ: lexemeIdentity, val: ""},
 			},
 		},
 		{
@@ -842,7 +844,9 @@ func TestLexer(t *testing.T) {
 			path: `$..["child"]`,
 			expected: []lexeme{
 				{typ: lexemeRoot, val: "$"},
-				{typ: lexemeError, val: `child name or array access or filter missing after recursive descent at position 3, following "$.."`},
+				{typ: lexemeRecursiveDescent, val: ".."},
+				{typ: lexemeBracketChild, val: `["child"]`},
+				{typ: lexemeIdentity, val: ""},
 			},
 		},
 		{

--- a/pkg/yamlpath/path_test.go
+++ b/pkg/yamlpath/path_test.go
@@ -1099,7 +1099,7 @@ another: entry`,
 			name:            "union with wildcard and numbers (deviation from comparison project consensus)",
 			input:           `["a","b","c"]`,
 			path:            `$[*,1,0,*]`,
-			expectedStrings: []string{"\"a\"\n", "\"b\"\n", "\"c\"\n", "\"b\"\n", "\"a\"\n", "\"a\"\n", "\"b\"\n", "\"c\"\n"},
+			expectedPathErr: `invalid array index [*,1,0,*] before position 10: error in union member 0: wildcard cannot be used in union`,
 		},
 		{
 			name:            "special characters in bracket child name",

--- a/pkg/yamlpath/slicer.go
+++ b/pkg/yamlpath/slicer.go
@@ -17,6 +17,10 @@ func slice(index string, length int) ([]int, error) {
 	if union := strings.Split(index, ","); len(union) > 1 {
 		combination := []int{}
 		for i, idx := range union {
+			// check wildcard, it cannot be used in union
+			if strings.TrimSpace(idx) == "*" {
+				return nil, fmt.Errorf("error in union member %d: wildcard cannot be used in union", i)
+			}
 			sl, err := slice(idx, length)
 			if err != nil {
 				return nil, fmt.Errorf("error in union member %d: %s", i, err)

--- a/pkg/yamlpath/slicer_test.go
+++ b/pkg/yamlpath/slicer_test.go
@@ -226,10 +226,16 @@ func TestSlicer(t *testing.T) {
 		},
 		{
 			name:        "union with duplicated results (deviation from comparison project consensus)",
-			index:       "*,1,0,1,*",
+			index:       "1,0,1",
 			length:      3,
-			expected:    []int{0, 1, 2, 1, 0, 1, 0, 1, 2},
+			expected:    []int{1, 0, 1},
 			expectedErr: "",
+		},
+		{
+			name:        "union with wildcard and index",
+			index:       "*,1",
+			length:      3,
+			expectedErr: "error in union member 0: wildcard cannot be used in union",
 		},
 		{
 			name:     "default indices with empty array",

--- a/test/testdata/regression_suite.yaml
+++ b/test/testdata/regression_suite.yaml
@@ -18,7 +18,7 @@
 # implementation.
 #
 # The consensus is not always a valid JSON document. In the case that the
-# consensus is that a query is nut supported it will contain the string
+# consensus is that a query is not supported it will contain the string
 # "NOT_SUPPORTED".
 
 queries:
@@ -38,12 +38,61 @@ queries:
   - id: array_slice_on_object
     selector: "$[1:3]"
     document: {":": 42, "more": "string", "a": 1, "b": 2, "c": 3, "1:3": "nice"}
+    consensus: []
   - id: array_slice_on_partially_overlapping_array
     selector: "$[1:10]"
     document: ["first", "second", "third"]
     consensus: ["second", "third"]
+  - id: array_slice_with_large_number_for_end
+    selector: "$[2:113667776004]"
+    document: ["first", "second", "third", "forth", "fifth"]
+    consensus: ["third", "forth", "fifth"]
+  - id: array_slice_with_large_number_for_end_and_negative_step
+    selector: "$[2:-113667776004:-1]"
+    document: ["first", "second", "third", "forth", "fifth"]
+  - id: array_slice_with_large_number_for_start
+    selector: "$[-113667776004:2]"
+    document: ["first", "second", "third", "forth", "fifth"]
+    consensus: ["first", "second"]
+  - id: array_slice_with_large_number_for_start_end_negative_step
+    selector: "$[113667776004:2:-1]"
+    document: ["first", "second", "third", "forth", "fifth"]
+  - id: array_slice_with_negative_start_and_end_and_range_of_-1
+    selector: "$[-4:-5]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: []
+    not-found-consensus: NOT_FOUND
+  - id: array_slice_with_negative_start_and_end_and_range_of_0
+    selector: "$[-4:-4]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: []
+    not-found-consensus: NOT_FOUND
+  - id: array_slice_with_negative_start_and_end_and_range_of_1
+    selector: "$[-4:-3]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: [4]
+  - id: array_slice_with_negative_start_and_positive_end_and_range_of_-1
+    selector: "$[-4:1]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: []
+    not-found-consensus: NOT_FOUND
+  - id: array_slice_with_negative_start_and_positive_end_and_range_of_0
+    selector: "$[-4:2]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: []
+    not-found-consensus: NOT_FOUND
+  - id: array_slice_with_negative_start_and_positive_end_and_range_of_1
+    selector: "$[-4:3]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: [4]
   - id: array_slice_with_negative_step
     selector: "$[3:0:-2]"
+    document: ["first", "second", "third", "forth", "fifth"]
+  - id: array_slice_with_negative_step_and_start_greater_than_end
+    selector: "$[0:3:-2]"
+    document: ["first", "second", "third", "forth", "fifth"]
+  - id: array_slice_with_negative_step_on_partially_overlapping_array
+    selector: "$[7:3:-1]"
     document: ["first", "second", "third", "forth", "fifth"]
   - id: array_slice_with_negative_step_only
     selector: "$[::-2]"
@@ -52,6 +101,9 @@ queries:
     selector: "$[1:]"
     document: ["first", "second", "third", "forth", "fifth"]
     consensus: ["second", "third", "forth", "fifth"]
+  - id: array_slice_with_open_end_and_negative_step
+    selector: "$[3::-1]"
+    document: ["first", "second", "third", "forth", "fifth"]
   - id: array_slice_with_open_start
     selector: "$[:2]"
     document: ["first", "second", "third", "forth", "fifth"]
@@ -67,6 +119,24 @@ queries:
   - id: array_slice_with_open_start_and_end_on_object
     selector: "$[:]"
     document: {":": 42, "more": "string"}
+    consensus: []
+  - id: array_slice_with_open_start_and_negative_step
+    selector: "$[:2:-1]"
+    document: ["first", "second", "third", "forth", "fifth"]
+  - id: array_slice_with_positive_start_and_negative_end_and_range_of_-1
+    selector: "$[3:-4]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: []
+    not-found-consensus: NOT_FOUND
+  - id: array_slice_with_positive_start_and_negative_end_and_range_of_0
+    selector: "$[3:-3]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: []
+    not-found-consensus: NOT_FOUND
+  - id: array_slice_with_positive_start_and_negative_end_and_range_of_1
+    selector: "$[3:-2]"
+    document: [2, "a", 4, 5, 100, "nice"]
+    consensus: [5]
   - id: array_slice_with_range_of_-1
     selector: "$[2:1]"
     document: ["first", "second", "third", "forth"]
@@ -166,6 +236,15 @@ queries:
   - id: bracket_notation_with_empty_string_doubled_quoted
     selector: "$[\"\"]"
     document: {"": 42, "''": 123, "\"\"": 222}
+    consensus: [42]
+    scalar-consensus: 42
+  - id: bracket_notation_with_negative_number_on_short_array
+    selector: "$[-2]"
+    document: ["one element"]
+    consensus: []
+    scalar-consensus: null
+    not-found-consensus: NOT_FOUND
+    scalar-not-found-consensus: NOT_FOUND
   - id: bracket_notation_with_number
     selector: "$[2]"
     document: ["first", "second", "third", "forth", "fifth"]
@@ -195,6 +274,10 @@ queries:
   - id: bracket_notation_with_number_on_object
     selector: "$[0]"
     document: {"0": "value"}
+    consensus: []
+    scalar-consensus: null
+    not-found-consensus: NOT_FOUND
+    scalar-not-found-consensus: NOT_FOUND
   - id: bracket_notation_with_number_on_short_array
     selector: "$[1]"
     document: ["one element"]
@@ -205,6 +288,10 @@ queries:
   - id: bracket_notation_with_number_on_string
     selector: "$[0]"
     document: "Hello World"
+    consensus: []
+    scalar-consensus: null
+    not-found-consensus: NOT_FOUND
+    scalar-not-found-consensus: NOT_FOUND
   - id: bracket_notation_with_quoted_array_slice_literal
     selector: "$[':']"
     document: {":": "value", "another": "entry"}
@@ -257,6 +344,7 @@ queries:
   - id: bracket_notation_with_quoted_string_and_unescaped_single_quote
     selector: "$['single'quote']"
     document: {"single'quote": "value"}
+    consensus: NOT_SUPPORTED
   - id: bracket_notation_with_quoted_union_literal
     selector: "$[',']"
     document: {",": "value", "another": "entry"}
@@ -265,11 +353,21 @@ queries:
   - id: bracket_notation_with_quoted_wildcard_literal
     selector: "$['*']"
     document: {"*": "value", "another": "entry"}
+    ordered: false
     consensus: ["value"]
     scalar-consensus: "value"
   - id: bracket_notation_with_quoted_wildcard_literal_on_object_without_key
     selector: "$['*']"
     document: {"another": "entry"}
+    consensus: []
+    scalar-consensus: null
+    not-found-consensus: NOT_FOUND
+    scalar-not-found-consensus: NOT_FOUND
+  - id: bracket_notation_with_spaces
+    selector: "$[ 'a' ]"
+    document: {" a": 1, "a": 2, " a ": 3, "a ": 4, " 'a' ": 5, " 'a": 6, "a' ": 7, " \"a\" ": 8, "\"a\"": 9}
+    consensus: [2]
+    scalar-consensus: 2
   - id: bracket_notation_with_string_including_dot_wildcard
     selector: "$['ni.*']"
     document: {"nice": 42, "ni.*": 1, "mice": 100}
@@ -278,6 +376,7 @@ queries:
   - id: bracket_notation_with_two_literals_separated_by_dot
     selector: "$['two'.'some']"
     document: {"one": {"key": "value"}, "two": {"some": "more", "key": "other value"}, "two.some": "42", "two'.'some": "43"}
+    consensus: NOT_SUPPORTED
   - id: bracket_notation_with_two_literals_separated_by_dot_without_quotes
     selector: "$[two.some]"
     document: {"one": {"key": "value"}, "two": {"some": "more", "key": "other value"}, "two.some": "42"}
@@ -321,6 +420,10 @@ queries:
   - id: bracket_notation_without_quotes
     selector: "$[key]"
     document: {"key": "value"}
+    consensus: NOT_SUPPORTED
+  - id: current_with_dot_notation
+    selector: "@.a"
+    document: {"a": 1}
   - id: dot_bracket_notation
     selector: "$.['key']"
     document: {"key": "value", "other": {"key": [{"key": 42}]}}
@@ -336,10 +439,15 @@ queries:
     document: {"key": "value"}
     consensus: ["value"]
     scalar-consensus: "value"
+  - id: dot_notation_after_array_slice
+    selector: "$[0:2].key"
+    document: [{"key": "ey"}, {"key": "bee"}, {"key": "see"}]
+    consensus: ["ey", "bee"]
   - id: dot_notation_after_bracket_notation_after_recursive_descent
     selector: "$..[1].key"
     document: {"k": [{"key": "some value"}, {"key": 42}], "kk": [[{"key": 100}, {"key": 200}, {"key": 300}], [{"key": 400}, {"key": 500}, {"key": 600}]], "key": [0, 1]}
     ordered: false
+    consensus: [200, 42, 500]
   - id: dot_notation_after_bracket_notation_with_wildcard
     selector: "$[*].a"
     document: [{"a": 1}, {"a": 1}]
@@ -366,6 +474,10 @@ queries:
     document: {"store": {"book": [{"category": "reference", "author": "Nigel Rees", "title": "Sayings of the Century", "price": 8.95}, {"category": "fiction", "author": "Evelyn Waugh", "title": "Sword of Honour", "price": 12.99}, {"category": "fiction", "author": "Herman Melville", "title": "Moby Dick", "isbn": "0-553-21311-3", "price": 8.99}, {"category": "fiction", "author": "J. R. R. Tolkien", "title": "The Lord of the Rings", "isbn": "0-395-19395-8", "price": 22.99}], "bicycle": {"color": "red", "price": 19.95}}}
     ordered: false
     consensus: [12.99, 19.95, 22.99, 8.95, 8.99]
+  - id: dot_notation_after_recursive_descent_with_extra_dot
+    selector: "$...key"
+    document: {"object": {"key": "value", "array": [{"key": "something"}, {"key": {"key": "russian dolls"}}]}, "key": "top"}
+    ordered: false
   - id: dot_notation_after_union
     selector: "$[0,2].key"
     document: [{"key": "ey"}, {"key": "bee"}, {"key": "see"}]
@@ -412,7 +524,7 @@ queries:
     scalar-not-found-consensus: NOT_FOUND
   - id: dot_notation_with_dash
     selector: "$.key-dash"
-    document: {"key-dash": "value"}
+    document: {"key": 42, "key-": 43, "-": 44, "dash": 45, "-dash": 46, "": 47, "key-dash": "value", "something": "else"}
     consensus: ["value"]
     scalar-consensus: "value"
   - id: dot_notation_with_double_quotes
@@ -467,6 +579,10 @@ queries:
   - id: dot_notation_with_number_-1
     selector: "$.-1"
     document: ["first", "second", "third", "forth", "fifth"]
+    consensus: []
+    scalar-consensus: null
+    not-found-consensus: NOT_FOUND
+    scalar-not-found-consensus: NOT_FOUND
   - id: dot_notation_with_number_on_object
     selector: "$.2"
     document: {"a": "first", "2": "second", "b": "third"}
@@ -482,6 +598,9 @@ queries:
   - id: dot_notation_with_single_quotes_and_dot
     selector: "$.'some.key'"
     document: {"some.key": 42, "some": {"key": "value"}, "'some.key'": 43}
+  - id: dot_notation_with_space_padded_key
+    selector: "$. a "
+    document: {" a": 1, "a": 2, " a ": 3, "": 4}
   - id: dot_notation_with_wildcard_after_dot_notation_after_dot_notation_with_wildcard
     selector: "$.*.bar.*"
     document: [{"bar": [42]}]
@@ -525,9 +644,19 @@ queries:
     document: {"some": "string", "int": 42, "object": {"key": "value"}, "array": [0, 1]}
     ordered: false
     consensus: ["string", 42, [0, 1], {"key": "value"}]
+  - id: dot_notation_without_dot
+    selector: "$a"
+    document: {"a": 1, "$a": 2}
+    consensus: NOT_SUPPORTED
   - id: dot_notation_without_root
+    selector: ".key"
+    document: {"key": "value"}
+  - id: dot_notation_without_root_and_dot
     selector: "key"
     document: {"key": "value"}
+  - id: empty
+    selector: ""
+    document: {"a": 42, "": 21}
   - id: filter_expression_after_dot_notation_with_wildcard_after_recursive_descent
     selector: "$..*[?(@.id>2)]"
     document: [{"complext": {"one": [{"name": "first", "id": 1}, {"name": "next", "id": 2}, {"name": "another", "id": 3}, {"name": "more", "id": 4}], "more": {"name": "next to last", "id": 5}}}, {"name": "last", "id": 6}]
@@ -545,6 +674,23 @@ queries:
   - id: filter_expression_with_boolean_and_operator
     selector: "$[?(@.key>42 && @.key<44)]"
     document: [{"key": 42}, {"key": 43}, {"key": 44}]
+    consensus: [{"key": 43}]
+  - id: filter_expression_with_boolean_and_operator_and_value_false
+    selector: "$[?(@.key>0 && false)]"
+    document: [{"key": 1}, {"key": 3}, {"key": "nice"}, {"key": true}, {"key": null}, {"key": false}, {"key": {}}, {"key": []}, {"key": -1}, {"key": 0}, {"key": ""}]
+  - id: filter_expression_with_boolean_and_operator_and_value_true
+    selector: "$[?(@.key>0 && true)]"
+    document: [{"key": 1}, {"key": 3}, {"key": "nice"}, {"key": true}, {"key": null}, {"key": false}, {"key": {}}, {"key": []}, {"key": -1}, {"key": 0}, {"key": ""}]
+  - id: filter_expression_with_boolean_or_operator
+    selector: "$[?(@.key>43 || @.key<43)]"
+    document: [{"key": 42}, {"key": 43}, {"key": 44}]
+    consensus: [{"key": 42}, {"key": 44}]
+  - id: filter_expression_with_boolean_or_operator_and_value_false
+    selector: "$[?(@.key>0 || false)]"
+    document: [{"key": 1}, {"key": 3}, {"key": "nice"}, {"key": true}, {"key": null}, {"key": false}, {"key": {}}, {"key": []}, {"key": -1}, {"key": 0}, {"key": ""}]
+  - id: filter_expression_with_boolean_or_operator_and_value_true
+    selector: "$[?(@.key>0 || true)]"
+    document: [{"key": 1}, {"key": 3}, {"key": "nice"}, {"key": true}, {"key": null}, {"key": false}, {"key": {}}, {"key": []}, {"key": -1}, {"key": 0}, {"key": ""}]
   - id: filter_expression_with_bracket_notation
     selector: "$[?(@['key']==42)]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"some": "value"}]
@@ -565,16 +711,25 @@ queries:
     document: {"1": ["a", "b"], "2": ["x", "y"]}
   - id: filter_expression_with_current_object
     selector: "$[?(@)]"
-    document: ["some value", null, "value", 0, 1, -1, "", [], {}]
+    document: ["some value", null, "value", 0, 1, -1, "", [], {}, false, true]
   - id: filter_expression_with_different_grouped_operators
     selector: "$[?(@.a && (@.b || @.c))]"
     document: [{"a": true}, {"a": true, "b": true}, {"a": true, "b": true, "c": true}, {"b": true, "c": true}, {"a": true, "c": true}, {"c": true}, {"b": true}]
   - id: filter_expression_with_different_ungrouped_operators
     selector: "$[?(@.a && @.b || @.c)]"
-    document: [{"a": true, "b": true}, {"c": true}, {"d": true}]
+    document: [{"a": true, "b": true}, {"a": true, "b": true, "c": true}, {"b": true, "c": true}, {"a": true, "c": true}, {"a": true}, {"b": true}, {"c": true}, {"d": true}, {}]
   - id: filter_expression_with_division
     selector: "$[?(@.key/10==5)]"
     document: [{"key": 60}, {"key": 50}, {"key": 10}, {"key": -50}, {"key/10": 5}]
+  - id: filter_expression_with_dot_notation_with_dash
+    selector: "$[?(@.key-dash == 'value')]"
+    document: [{"key-dash": "value"}]
+  - id: filter_expression_with_dot_notation_with_number
+    selector: "$[?(@.2 == 'second')]"
+    document: [{"a": "first", "2": "second", "b": "third"}]
+  - id: filter_expression_with_dot_notation_with_number_on_array
+    selector: "$[?(@.2 == 'third')]"
+    document: [["first", "second", "third", "forth", "fifth"]]
   - id: filter_expression_with_empty_expression
     selector: "$[?()]"
     document: [1, {"key": 42}, "value", null]
@@ -585,15 +740,36 @@ queries:
   - id: filter_expression_with_equals_array
     selector: "$[?(@.d==[\"v1\",\"v2\"])]"
     document: [{"d": ["v1", "v2"]}, {"d": ["a", "b"]}, {"d": "v1"}, {"d": "v2"}, {"d": {}}, {"d": []}, {"d": null}, {"d": -1}, {"d": 0}, {"d": 1}, {"d": "['v1','v2']"}, {"d": "['v1', 'v2']"}, {"d": "v1,v2"}, {"d": "[\"v1\", \"v2\"]"}, {"d": "[\"v1\",\"v2\"]"}]
+  - id: filter_expression_with_equals_array_for_array_slice_with_range_1
+    selector: "$[?(@[0:1]==[1])]"
+    document: [[1, 2, 3], [1], [2, 3], 1, 2]
+  - id: filter_expression_with_equals_array_for_dot_notation_with_star
+    selector: "$[?(@.*==[1,2])]"
+    document: [[1, 2], [2, 3], [1], [2], [1, 2, 3], 1, 2, 3]
+  - id: filter_expression_with_equals_array_or_equals_true
+    selector: "$[?(@.d==[\"v1\",\"v2\"] || (@.d == true))]"
+    document: [{"d": ["v1", "v2"]}, {"d": ["a", "b"]}, {"d": true}]
   - id: filter_expression_with_equals_array_with_single_quotes
     selector: "$[?(@.d==['v1','v2'])]"
     document: [{"d": ["v1", "v2"]}, {"d": ["a", "b"]}, {"d": "v1"}, {"d": "v2"}, {"d": {}}, {"d": []}, {"d": null}, {"d": -1}, {"d": 0}, {"d": 1}, {"d": "['v1','v2']"}, {"d": "['v1', 'v2']"}, {"d": "v1,v2"}, {"d": "[\"v1\", \"v2\"]"}, {"d": "[\"v1\",\"v2\"]"}]
+  - id: filter_expression_with_equals_boolean_expression_value
+    selector: "$[?((@.key<44)==false)]"
+    document: [{"key": 42}, {"key": 43}, {"key": 44}]
   - id: filter_expression_with_equals_false
     selector: "$[?(@.key==false)]"
     document: [{"some": "some value"}, {"key": true}, {"key": false}, {"key": null}, {"key": "value"}, {"key": ""}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": 42}, {"key": {}}, {"key": []}]
   - id: filter_expression_with_equals_null
     selector: "$[?(@.key==null)]"
     document: [{"some": "some value"}, {"key": true}, {"key": false}, {"key": null}, {"key": "value"}, {"key": ""}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": 42}, {"key": {}}, {"key": []}]
+  - id: filter_expression_with_equals_number_for_array_slice_with_range_1
+    selector: "$[?(@[0:1]==1)]"
+    document: [[1, 2, 3], [1], [2, 3], 1, 2]
+  - id: filter_expression_with_equals_number_for_bracket_notation_with_star
+    selector: "$[?(@[*]==2)]"
+    document: [[1, 2], [2, 3], [1], [2], [1, 2, 3], 1, 2, 3]
+  - id: filter_expression_with_equals_number_for_dot_notation_with_star
+    selector: "$[?(@.*==2)]"
+    document: [[1, 2], [2, 3], [1], [2], [1, 2, 3], 1, 2, 3]
   - id: filter_expression_with_equals_number_with_fraction
     selector: "$[?(@.key==-0.123e2)]"
     document: [{"key": -12.3}, {"key": -0.123}, {"key": -12}, {"key": 12.3}, {"key": 2}, {"key": "-0.123e2"}]
@@ -606,6 +782,7 @@ queries:
   - id: filter_expression_with_equals_on_array_of_numbers
     selector: "$[?(@==42)]"
     document: [0, 42, -1, 41, 43, 42.0001, 41.9999, null, 100]
+    consensus: [42]
   - id: filter_expression_with_equals_on_array_without_match
     selector: "$[?(@.key==43)]"
     document: [{"key": 42}]
@@ -617,9 +794,17 @@ queries:
   - id: filter_expression_with_equals_on_object_with_key_matching_query
     selector: "$[?(@.id==2)]"
     document: {"id": 2}
+    consensus: []
+    not-found-consensus: NOT_FOUND
+    focus: true
   - id: filter_expression_with_equals_string
     selector: "$[?(@.key==\"value\")]"
     document: [{"key": "some"}, {"key": "value"}, {"key": null}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": ""}, {"key": {}}, {"key": []}, {"key": "valuemore"}, {"key": "morevalue"}, {"key": ["value"]}, {"key": {"some": "value"}}, {"key": {"key": "value"}}, {"some": "value"}]
+    consensus: [{"key": "value"}]
+  - id: filter_expression_with_equals_string_in_NFC
+    selector: "$[?(@.key==\"Motörhead\")]"
+    document: [{"key": "something"}, {"key": "Mot\u00f6rhead"}, {"key": "mot\u00f6rhead"}, {"key": "Motorhead"}, {"key": "Motoo\u0308rhead"}, {"key": "motoo\u0308rhead"}]
+    consensus: [{"key": "Mot\u00f6rhead"}]
   - id: filter_expression_with_equals_string_with_current_object_literal
     selector: "$[?(@.key==\"hi@example.com\")]"
     document: [{"key": "some"}, {"key": "value"}, {"key": "hi@example.com"}]
@@ -632,9 +817,15 @@ queries:
     selector: "$[?(@.key=='value')]"
     document: [{"key": "some"}, {"key": "value"}]
     consensus: [{"key": "value"}]
+  - id: filter_expression_with_equals_string_with_unicode_character_escape
+    selector: "$[?(@.key==\"Mot\\u00f6rhead\")]"
+    document: [{"key": "something"}, {"key": "Mot\u00f6rhead"}, {"key": "mot\u00f6rhead"}, {"key": "Motorhead"}, {"key": "Motoo\u0308rhead"}, {"key": "motoo\u0308rhead"}]
   - id: filter_expression_with_equals_true
     selector: "$[?(@.key==true)]"
     document: [{"some": "some value"}, {"key": true}, {"key": false}, {"key": null}, {"key": "value"}, {"key": ""}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": 42}, {"key": {}}, {"key": []}]
+  - id: filter_expression_with_equals_with_path_and_path
+    selector: "$[?(@.key1==@.key2)]"
+    document: [{"key1": 10, "key2": 10}, {"key1": 42, "key2": 50}, {"key1": 10}, {"key2": 10}, {}, {"key1": null, "key2": null}, {"key1": null}, {"key2": null}, {"key1": 0, "key2": 0}, {"key1": 0}, {"key2": 0}, {"key1": -1, "key2": -1}, {"key1": "", "key2": ""}, {"key1": false, "key2": false}, {"key1": false}, {"key2": false}, {"key1": true, "key2": true}, {"key1": [], "key2": []}, {"key1": {}, "key2": {}}, {"key1": {"a": 1, "b": 2}, "key2": {"b": 2, "a": 1}}]
   - id: filter_expression_with_equals_with_root_reference
     selector: "$.items[?(@.key==$.value)]"
     document: {"value": 42, "items": [{"key": 10}, {"key": 42}, {"key": 50}]}
@@ -644,33 +835,75 @@ queries:
   - id: filter_expression_with_greater_than_or_equal
     selector: "$[?(@.key>=42)]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "43"}, {"key": "42"}, {"key": "41"}, {"key": "value"}, {"some": "value"}]
+  - id: filter_expression_with_greater_than_string
+    selector: "$[?(@.key>\"VALUE\")]"
+    document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "43"}, {"key": "42"}, {"key": "41"}, {"key": "alpha"}, {"key": "ALPHA"}, {"key": "value"}, {"key": "VALUE"}, {"some": "value"}, {"some": "VALUE"}]
   - id: filter_expression_with_in_array_of_values
     selector: "$[?(@.d in [2, 3])]"
     document: [{"d": 1}, {"d": 2}, {"d": 1}, {"d": 3}, {"d": 4}]
   - id: filter_expression_with_in_current_object
     selector: "$[?(2 in @.d)]"
     document: [{"d": [1, 2, 3]}, {"d": [2]}, {"d": [1]}, {"d": [3, 4]}, {"d": [4, 2]}]
+  - id: filter_expression_with_length_free_function
+    selector: "$[?(length(@) == 4)]"
+    document: [[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3]]
+  - id: filter_expression_with_length_function
+    selector: "$[?(@.length() == 4)]"
+    document: [[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3]]
+  - id: filter_expression_with_length_property
+    selector: "$[?(@.length == 4)]"
+    document: [[1, 2, 3, 4, 5], [1, 2, 3, 4], [1, 2, 3]]
+    consensus: []
   - id: filter_expression_with_less_than
     selector: "$[?(@.key<42)]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "43"}, {"key": "42"}, {"key": "41"}, {"key": "value"}, {"some": "value"}]
   - id: filter_expression_with_less_than_or_equal
     selector: "$[?(@.key<=42)]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "43"}, {"key": "42"}, {"key": "41"}, {"key": "value"}, {"some": "value"}]
+  - id: filter_expression_with_local_dot_key_and_null_in_data
+    selector: "$[?(@.key='value')]"
+    document: [{"key": 0}, {"key": "value"}, null, {"key": 42}, {"some": "value"}]
+    consensus: NOT_SUPPORTED
   - id: filter_expression_with_multiplication
     selector: "$[?(@.key*2==100)]"
     document: [{"key": 60}, {"key": 50}, {"key": 10}, {"key": -50}, {"key*2": 100}]
   - id: filter_expression_with_negation_and_equals
     selector: "$[?(!(@.key==42))]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "43"}, {"key": "42"}, {"key": "41"}, {"key": "value"}, {"some": "value"}]
+  - id: filter_expression_with_negation_and_equals_array_or_equals_true
+    selector: "$[?(!(@.d==[\"v1\",\"v2\"]) || (@.d == true))]"
+    document: [{"d": ["v1", "v2"]}, {"d": ["a", "b"]}, {"d": true}]
   - id: filter_expression_with_negation_and_less_than
     selector: "$[?(!(@.key<42))]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "43"}, {"key": "42"}, {"key": "41"}, {"key": "value"}, {"some": "value"}]
+  - id: filter_expression_with_negation_and_without_value
+    selector: "$[?(!@.key)]"
+    document: [{"some": "some value"}, {"key": true}, {"key": false}, {"key": null}, {"key": "value"}, {"key": ""}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": 42}, {"key": {}}, {"key": []}]
+  - id: filter_expression_with_non_singular_existence_test
+    selector: "$[?(@.a.*)]"
+    document: [{"a": 0}, {"a": "x"}, {"a": false}, {"a": true}, {"a": null}, {"a": []}, {"a": [1]}, {"a": [1, 2]}, {"a": {}}, {"a": {"x": "y"}}, {"a": {"x": "y", "w": "z"}}]
   - id: filter_expression_with_not_equals
     selector: "$[?(@.key!=42)]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "some"}, {"key": "42"}, {"key": null}, {"key": 420}, {"key": ""}, {"key": {}}, {"key": []}, {"key": [42]}, {"key": {"key": 42}}, {"key": {"some": 42}}, {"some": "value"}]
+  - id: filter_expression_with_not_equals_array_or_equals_true
+    selector: "$[?((@.d!=[\"v1\",\"v2\"]) || (@.d == true))]"
+    document: [{"d": ["v1", "v2"]}, {"d": ["a", "b"]}, {"d": true}]
+  - id: filter_expression_with_parent_axis_operator
+    selector: "$[*].bookmarks[?(@.page == 45)]^^^"
+    document: [{"title": "Sayings of the Century", "bookmarks": [{"page": 40}]}, {"title": "Sword of Honour", "bookmarks": [{"page": 35}, {"page": 45}]}, {"title": "Moby Dick", "bookmarks": [{"page": 3035}, {"page": 45}]}]
+    consensus: NOT_SUPPORTED
   - id: filter_expression_with_regular_expression
     selector: "$[?(@.name=~/hello.*/)]"
     document: [{"name": "hullo world"}, {"name": "hello world"}, {"name": "yes hello world"}, {"name": "HELLO WORLD"}, {"name": "good bye"}]
+  - id: filter_expression_with_regular_expression_from_member
+    selector: "$[?(@.name=~/@.pattern/)]"
+    document: [{"name": "hullo world"}, {"name": "hello world"}, {"name": "yes hello world"}, {"name": "HELLO WORLD"}, {"name": "good bye"}, {"pattern": "hello.*"}]
+  - id: filter_expression_with_set_wise_comparison_to_scalar
+    selector: "$[?(@[*]>=4)]"
+    document: [[1, 2], [3, 4], [5, 6]]
+  - id: filter_expression_with_set_wise_comparison_to_set
+    selector: "$.x[?(@[*]>=$.y[*])]"
+    document: {"x": [[1, 2], [3, 4], [5, 6]], "y": [3, 4, 5]}
   - id: filter_expression_with_single_equal
     selector: "$[?(@.key=42)]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "some"}, {"key": "42"}, {"key": null}, {"key": 420}, {"key": ""}, {"key": {}}, {"key": []}, {"key": [42]}, {"key": {"key": 42}}, {"key": {"some": 42}}, {"some": "value"}]
@@ -678,22 +911,53 @@ queries:
   - id: filter_expression_with_subfilter
     selector: "$[?(@.a[?(@.price>10)])]"
     document: [{"a": [{"price": 1}, {"price": 3}]}, {"a": [{"price": 11}]}, {"a": [{"price": 8}, {"price": 12}, {"price": 3}]}, {"a": []}]
+  - id: filter_expression_with_subpaths
+    selector: "$[?(@.address.city=='Berlin')]"
+    document: [{"address": {"city": "Berlin"}}, {"address": {"city": "London"}}]
+    consensus: [{"address": {"city": "Berlin"}}]
   - id: filter_expression_with_subtraction
     selector: "$[?(@.key-50==-100)]"
     document: [{"key": 60}, {"key": 50}, {"key": 10}, {"key": -50}, {"key-50": -100}]
+  - id: filter_expression_with_tautological_comparison
+    selector: "$[?(1==1)]"
+    document: [1, 3, "nice", true, null, false, {}, [], -1, 0, ""]
   - id: filter_expression_with_triple_equal
     selector: "$[?(@.key===42)]"
     document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "some"}, {"key": "42"}, {"key": null}, {"key": 420}, {"key": ""}, {"key": {}}, {"key": []}, {"key": [42]}, {"key": {"key": 42}}, {"key": {"some": 42}}, {"some": "value"}]
   - id: filter_expression_with_value
     selector: "$[?(@.key)]"
     document: [{"some": "some value"}, {"key": true}, {"key": false}, {"key": null}, {"key": "value"}, {"key": ""}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": 42}, {"key": {}}, {"key": []}]
+  - id: filter_expression_with_value_after_dot_notation_with_wildcard_on_array_of_objects
+    selector: "$.*[?(@.key)]"
+    document: [{"some": "some value"}, {"key": "value"}]
+    consensus: []
+    not-found-consensus: NOT_FOUND
   - id: filter_expression_with_value_after_recursive_descent
     selector: "$..[?(@.id)]"
     document: {"id": 2, "more": [{"id": 2}, {"more": {"id": 2}}, {"id": {"id": 2}}, [{"id": 2}]]}
     ordered: false
+  - id: filter_expression_with_value_false
+    selector: "$[?(false)]"
+    document: [1, 3, "nice", true, null, false, {}, [], -1, 0, ""]
+  - id: filter_expression_with_value_from_recursive_descent
+    selector: "$[?(@..child)]"
+    document: [{"key": [{"child": 1}, {"child": 2}]}, {"key": [{"child": 2}]}, {"key": [{}]}, {"key": [{"something": 42}]}, {}]
+  - id: filter_expression_with_value_null
+    selector: "$[?(null)]"
+    document: [1, 3, "nice", true, null, false, {}, [], -1, 0, ""]
+  - id: filter_expression_with_value_true
+    selector: "$[?(true)]"
+    document: [1, 3, "nice", true, null, false, {}, [], -1, 0, ""]
+  - id: filter_expression_without_parens
+    selector: "$[?@.key==42]"
+    document: [{"key": 0}, {"key": 42}, {"key": -1}, {"key": 1}, {"key": 41}, {"key": 43}, {"key": 42.0001}, {"key": 41.9999}, {"key": 100}, {"key": "some"}, {"key": "42"}, {"key": null}, {"key": 420}, {"key": ""}, {"key": {}}, {"key": []}, {"key": [42]}, {"key": {"key": 42}}, {"key": {"some": 42}}, {"some": "value"}]
+    consensus: NOT_SUPPORTED
   - id: filter_expression_without_value
-    selector: "$[?(!@.key)]"
+    selector: "$[?(@.key)]"
     document: [{"some": "some value"}, {"key": true}, {"key": false}, {"key": null}, {"key": "value"}, {"key": ""}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": 42}, {"key": {}}, {"key": []}]
+  - id: function_sum
+    selector: "$.data.sum()"
+    document: {"data": [1, 2, 3, 4]}
   - id: parens_notation
     selector: "$(key,more)"
     document: {"key": 1, "some": 2, "more": 3}
@@ -706,6 +970,10 @@ queries:
     selector: "$.key.."
     document: {"some key": "value", "key": {"complex": "string", "primitives": [0, 1]}}
     ordered: false
+  - id: recursive_descent_on_nested_arrays
+    selector: "$..*"
+    document: [[0], [1]]
+    consensus: [[0], [1], 0, 1]
   - id: root
     selector: "$"
     document: {"key": "value", "another key": {"complex": ["a", 1]}}
@@ -729,10 +997,19 @@ queries:
   - id: script_expression
     selector: "$[(@.length-1)]"
     document: ["first", "second", "third", "forth", "fifth"]
+    consensus: NOT_SUPPORTED
   - id: union
     selector: "$[0,1]"
     document: ["first", "second", "third"]
     consensus: ["first", "second"]
+  - id: union_with_duplication_from_array
+    selector: "$[0,0]"
+    document: ["a"]
+    consensus: ["a", "a"]
+  - id: union_with_duplication_from_object
+    selector: "$['a','a']"
+    document: {"a": 1}
+    consensus: [1, 1]
   - id: union_with_filter
     selector: "$[?(@.key<3),?(@.key>6)]"
     document: [{"key": 1}, {"key": 8}, {"key": 3}, {"key": 10}, {"key": 7}, {"key": 2}, {"key": 6}, {"key": 4}]
@@ -743,6 +1020,7 @@ queries:
   - id: union_with_keys_after_array_slice
     selector: "$[:]['c','d']"
     document: [{"c": "cc1", "d": "dd1", "e": "ee1"}, {"c": "cc2", "d": "dd2", "e": "ee2"}]
+    consensus: ["cc1", "dd1", "cc2", "dd2"]
   - id: union_with_keys_after_bracket_notation
     selector: "$[0]['c','d']"
     document: [{"c": "cc1", "d": "dd1", "e": "ee1"}, {"c": "cc2", "d": "dd2", "e": "ee2"}]
@@ -750,6 +1028,12 @@ queries:
   - id: union_with_keys_after_dot_notation_with_wildcard
     selector: "$.*['c','d']"
     document: [{"c": "cc1", "d": "dd1", "e": "ee1"}, {"c": "cc2", "d": "dd2", "e": "ee2"}]
+    consensus: ["cc1", "dd1", "cc2", "dd2"]
+  - id: union_with_keys_after_recursive_descent
+    selector: "$..['c','d']"
+    document: [{"c": "cc1", "d": "dd1", "e": "ee1"}, {"c": "cc2", "child": {"d": "dd2"}}, {"c": "cc3"}, {"d": "dd4"}, {"child": {"c": "cc5"}}]
+    ordered: false
+    consensus: ["cc1", "cc2", "cc3", "cc5", "dd1", "dd2", "dd4"]
   - id: union_with_keys_on_object_without_key
     selector: "$['missing','key']"
     document: {"key": "value", "another": "entry"}
@@ -758,6 +1042,9 @@ queries:
     selector: "$[4,1]"
     document: [1, 2, 3, 4, 5]
     consensus: [5, 2]
+  - id: union_with_repeated_matches_after_dot_notation_with_wildcard
+    selector: "$.*[0,:5]"
+    document: {"a": ["string", null, true], "b": [false, "string", 5.4]}
   - id: union_with_slice_and_number
     selector: "$[1:3,4]"
     document: [1, 2, 3, 4, 5]
@@ -766,7 +1053,6 @@ queries:
     document: ["first", "second", "third"]
     consensus: ["first", "second"]
   - id: union_with_wildcard_and_number
-    exclude: true
     selector: "$[*,1]"
     document: ["first", "second", "third", "forth", "fifth"]
     consensus: NOT_SUPPORTED

--- a/test/testdata/regression_suite.yaml
+++ b/test/testdata/regression_suite.yaml
@@ -796,7 +796,6 @@ queries:
     document: {"id": 2}
     consensus: []
     not-found-consensus: NOT_FOUND
-    focus: true
   - id: filter_expression_with_equals_string
     selector: "$[?(@.key==\"value\")]"
     document: [{"key": "some"}, {"key": "value"}, {"key": null}, {"key": 0}, {"key": 1}, {"key": -1}, {"key": ""}, {"key": {}}, {"key": []}, {"key": "valuemore"}, {"key": "morevalue"}, {"key": ["value"]}, {"key": {"some": "value"}}, {"key": {"key": "value"}}, {"some": "value"}]


### PR DESCRIPTION
Updated latest [regression tests document](https://github.com/cburgmer/json-path-comparison) document and fixed failing tests.

There are two cases that I could not fix:

- Fixing this case will remove the ability to test for the existence of a key in a `yaml.MappingNode`

```yaml
  - id: filter_expression_with_value_after_dot_notation_with_wildcard_on_array_of_objects
    selector: "$.*[?(@.key)]"
    document: [{"some": "some value"}, {"key": "value"}]
    consensus: []
    not-found-consensus: NOT_FOUND
```

Actual result:

```json
[{"key": "value"}]
```

- I do not see anything wrong in the `yaml-jsonpath` response

```yaml
  - id: filter_expression_with_equals_on_object_with_key_matching_query
    selector: "$[?(@.id==2)]"
    document: {"id": 2}
    consensus: []
    not-found-consensus: NOT_FOUND
```

Actual result:

```json
[{"id": 2}]
```

I used this library as a base to a `Json` implementation (see [github.com/SteelBridgeLabs/jsonpath](https://github.com/SteelBridgeLabs/jsonpath)). All these fixes are based on updates I did on the Json library.

